### PR TITLE
Feat(#1)/manage 페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # Claude
 .claude/
+
+# etc
+study.md

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-#Claude
-CLAUDE.md
+# Claude
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,157 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+TEEKY is a web application for university students - a personalized study assistant. The frontend is built with Next.js 15 (App Router), React 19, TypeScript, and Tailwind CSS v4. It uses shadcn/ui (base-nova style, @base-ui/react 기반) as the component library and a mobile-first design approach with a fixed 375px width layout optimized for web apps.
+
+## Development Commands
+
+```bash
+# Start development server (runs on http://localhost:3000)
+npm run dev
+
+# Build for production
+npm run build
+
+# Run production build locally
+npm start
+
+# Run linter
+npm run lint
+```
+
+## Architecture
+
+### Project Structure
+
+The project follows Next.js 15 App Router conventions with a custom organization pattern:
+
+```
+app/
+├── (main)/                      # Main page routes (Next.js route group)
+│   ├── page.tsx                 # Home page (subjects list)
+│   └── subjects/[subjectId]/
+│       ├── page.tsx             # Subject detail (weeks list)
+│       └── records/[recordId]/
+│           ├── page.tsx         # Record detail (feature cards)
+│           └── manage/
+│               ├── page.tsx     # File management page
+│               └── move/
+│                   └── page.tsx # File move page
+├── _components/                 # Shared components (underscore prefix excludes from routing)
+│   ├── ui/                      # shadcn/ui primitives (button, card, dialog, etc.)
+│   ├── layout/                  # Layout components (AppShell, Header, BottomNav)
+│   ├── shared/                  # Reusable components (ListItem, EmptyState, etc.)
+│   └── pages/                   # Page-specific components
+│       ├── records/             # Record detail page components
+│       └── manage/              # File management page components
+│           └── move/            # File move page components
+├── _lib/                        # Utility functions and libraries
+│   ├── utils.ts                 # cn() helper (clsx + tailwind-merge)
+│   └── mock/                    # Mock data and simulation functions
+├── types.ts                     # Shared TypeScript types
+├── layout.tsx                   # Root layout (font, Toaster)
+└── globals.css                  # Global styles, Tailwind v4 theme, CSS variables
+```
+
+**Key architectural decisions:**
+
+- **Route groups:** `(main)` folder enables logical grouping without affecting URL structure
+- **Private folders:** Folders prefixed with `_` are excluded from Next.js routing but remain part of the project structure
+- **Component organization:** `ui/` for shadcn primitives, `layout/` for shell components, `shared/` for reusable components, `pages/{pageName}/` for page-specific components
+- **Absolute imports:** All imports use the `@/` alias (e.g., `@/app/_components/pages/manage/...`) configured in tsconfig.json
+- **Mock data:** `_lib/mock/` contains mock data and simulation functions for features where the backend is not yet implemented
+
+### Installed shadcn/ui Components
+
+alert-dialog, badge, button, card, checkbox, dialog, input, progress, separator, sonner(toast)
+
+### Styling Approach
+
+- **Tailwind CSS v4** with inline theme configuration in globals.css
+- **Design system:** Mobile-first, 375px fixed-width container centered on larger screens (AppShell)
+- **Color scheme:** oklch CSS variables 기반 (`--primary`, `--background`, `--card`, `--muted`, etc.)
+- **Typography:** Pretendard (Korean sans-serif, `@font-face` in globals.css), Geist Mono as monospace fallback
+- **Component patterns:** Components accept `className` prop, merging with base styles via `cn()` utility
+- **Toast notifications:** Sonner 기반, root layout에 `<Toaster>` 전역 설정
+
+### Component Patterns
+
+All components follow these conventions:
+
+1. **Type definitions inline** - Props types defined above component (not in separate files)
+2. **Style composition** - Base styles merged with optional `className` via `cn()` utility or array filter/join pattern
+3. **Props spreading** - Button components spread remaining HTML attributes with `...rest`
+4. **Children support** - Container components use `PropsWithChildren<T>` for type safety
+
+Example pattern:
+```typescript
+type ComponentProps = {
+  title: string;
+  className?: string;
+};
+
+export function Component({ title, className }: ComponentProps) {
+  const wrapperClass = [
+    "base-styles",
+    className,
+  ].filter(Boolean).join(" ");
+
+  return <div className={wrapperClass}>{title}</div>;
+}
+```
+
+### TypeScript Configuration
+
+- Strict mode enabled
+- Path alias: `@/*` maps to `./*` (project root)
+- Target: ES2017
+- JSX: preserve (handled by Next.js)
+
+## Development Guidelines
+
+### Adding New Components
+
+1. **shadcn/ui primitives:** `app/_components/ui/` (install via `npx shadcn@latest add <component>`)
+2. **Layout components:** `app/_components/layout/`
+3. **Reusable shared components:** `app/_components/shared/`
+4. **Page-specific components:** `app/_components/pages/{pageName}/`
+5. Use TypeScript with inline prop type definitions
+6. Accept `className` prop for style customization
+
+### Adding New Pages
+
+- Create in `app/(main)/` for main app routes
+- Page-specific components go in `app/_components/pages/{pageName}/`, NOT in route-colocated `_components/`
+- Import components using absolute paths: `@/app/_components/...`
+- Follow mobile-first responsive design (375px base width)
+
+### Working with Types
+
+- Shared types go in `app/types.ts`
+- Feature-specific types can be co-located in `app/_lib/mock/` (for mock-backed features) or relevant lib directories
+- Component-specific types are defined inline above the component
+- Use proper TypeScript utility types (PropsWithChildren, ButtonHTMLAttributes, etc.)
+
+### Styling
+
+- Use Tailwind utility classes directly in components
+- Use CSS variable tokens (`bg-primary`, `text-muted-foreground`, etc.) instead of hardcoded colors
+- Maintain consistent spacing, border-radius (`rounded-xl`, `rounded-2xl`), and ring patterns (`ring-1 ring-foreground/10`)
+- Scrollable containers with `ring` children: add padding (`p-0.5 -m-0.5`) to prevent ring clipping from `overflow-y-auto`
+- Minimum 44px touch target for interactive elements on mobile
+
+### Git Commit Convention
+
+```
+{Type}/#{issueNumber}: 설명
+```
+
+Types: `Feat`, `Fix`, `Refactor`, `Style`, `ci`, `Docs`
+
+Examples:
+- `Feat/#1: 파일관리 페이지 컴포넌트 구현`
+- `Refactor: shadcn 기반 UI 개선`
+- `ci: 이슈, PR 템플릿 적용`

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/move/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/move/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { use, useState, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { AppShell } from "@/app/_components/layout/AppShell";
+import { toast } from "sonner";
+import type { WeekFolder } from "@/app/_lib/mock/manage-types";
+import { mockWeekFolders } from "@/app/_lib/mock/manage-data";
+import { simulateMove } from "@/app/_lib/mock/manage-actions";
+
+import { FolderList } from "@/app/_components/pages/manage/move/FolderList";
+import { MoveConfirmDialog } from "@/app/_components/pages/manage/move/MoveConfirmDialog";
+
+const recordToWeek: Record<string, number> = {
+  "1": 1,
+  "2": 2,
+  "3": 3,
+};
+
+export default function MovePage({
+  params,
+}: {
+  params: Promise<{ subjectId: string; recordId: string }>;
+}) {
+  const { subjectId, recordId } = use(params);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const fileIds = (searchParams.get("files") ?? "").split(",").filter(Boolean);
+  const currentWeek = recordToWeek[recordId] ?? 1;
+
+  const folders: WeekFolder[] = mockWeekFolders.map((f) => ({
+    ...f,
+    isCurrent: f.weekNumber === currentWeek,
+  }));
+
+  const [selectedFolder, setSelectedFolder] = useState<WeekFolder | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleSelectFolder = useCallback((folder: WeekFolder) => {
+    setSelectedFolder(folder);
+    setDialogOpen(true);
+  }, []);
+
+  const handleConfirmMove = useCallback(async () => {
+    if (!selectedFolder) return;
+
+    const result = await simulateMove(fileIds, selectedFolder.weekNumber);
+
+    setDialogOpen(false);
+
+    if (result === "success") {
+      toast.success("파일 이동이 완료되었습니다.");
+      setTimeout(() => {
+        router.push(`/subjects/${subjectId}/records/${recordId}/manage`);
+      }, 500);
+    } else {
+      toast.error("파일 이동 중 오류가 발생하였습니다!");
+    }
+  }, [selectedFolder, fileIds, router, subjectId, recordId]);
+
+  return (
+    <AppShell title="파일 이동" showBack>
+      <div className="flex flex-col gap-4 p-4">
+        <p className="text-xs text-muted-foreground">
+          {fileIds.length}개 파일을 이동할 폴더를 선택하세요
+        </p>
+        <FolderList folders={folders} onSelect={handleSelectFolder} />
+      </div>
+
+      {selectedFolder && (
+        <MoveConfirmDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          currentWeek={currentWeek}
+          targetWeek={selectedFolder.weekNumber}
+          onConfirm={handleConfirmMove}
+        />
+      )}
+    </AppShell>
+  );
+}

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/move/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/move/page.tsx
@@ -11,12 +11,6 @@ import { simulateMove } from "@/app/_lib/mock/manage-actions";
 import { FolderList } from "@/app/_components/pages/manage/move/FolderList";
 import { MoveConfirmDialog } from "@/app/_components/pages/manage/move/MoveConfirmDialog";
 
-const recordToWeek: Record<string, number> = {
-  "1": 1,
-  "2": 2,
-  "3": 3,
-};
-
 export default function MovePage({
   params,
 }: {
@@ -27,7 +21,7 @@ export default function MovePage({
   const searchParams = useSearchParams();
 
   const fileIds = (searchParams.get("files") ?? "").split(",").filter(Boolean);
-  const currentWeek = recordToWeek[recordId] ?? 1;
+  const currentWeek = parseInt(recordId, 10) || 1;
 
   const folders: WeekFolder[] = mockWeekFolders.map((f) => ({
     ...f,

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { use, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { AppShell } from "@/app/_components/layout/AppShell";
+import { Button } from "@/app/_components/ui/button";
+import { toast } from "sonner";
+import type {
+  UploadFile,
+  CompletedFile,
+  ManagePageMode,
+} from "@/app/_lib/mock/manage-types";
+import {
+  mockCompletedFiles,
+  mockCapacity,
+} from "@/app/_lib/mock/manage-data";
+import {
+  simulateUpload,
+  simulateLearning,
+  simulateDelete,
+} from "@/app/_lib/mock/manage-actions";
+
+import { CapacityIndicator } from "@/app/_components/pages/manage/CapacityIndicator";
+import { FileUploadZone } from "@/app/_components/pages/manage/FileUploadZone";
+import { UploadFileList } from "@/app/_components/pages/manage/UploadFileList";
+import { AiLearningStatus } from "@/app/_components/pages/manage/AiLearningStatus";
+import { LearningCompleteView } from "@/app/_components/pages/manage/LearningCompleteView";
+import { LearningErrorView } from "@/app/_components/pages/manage/LearningErrorView";
+import { CompletedFileList } from "@/app/_components/pages/manage/CompletedFileList";
+import { EditModeView } from "@/app/_components/pages/manage/EditModeView";
+
+const subjectNames: Record<string, string> = {
+  "1": "데이터베이스",
+  "2": "알고리즘",
+  "3": "자료구조",
+};
+
+const recordNames: Record<string, string> = {
+  "1": "1주차",
+  "2": "2주차",
+  "3": "3주차",
+};
+
+const MAX_FILES_PER_BATCH = 5;
+
+export default function ManagePage({
+  params,
+}: {
+  params: Promise<{ subjectId: string; recordId: string }>;
+}) {
+  const { subjectId, recordId } = use(params);
+  const router = useRouter();
+
+  const subjectName = subjectNames[subjectId] ?? "과목";
+  const recordTitle = recordNames[recordId] ?? `${recordId}주차`;
+  const breadcrumb = `${subjectName} > ${recordTitle}`;
+
+  const [mode, setMode] = useState<ManagePageMode>("idle");
+  const [completedFiles, setCompletedFiles] =
+    useState<CompletedFile[]>(mockCompletedFiles);
+  const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([]);
+  const [capacity, setCapacity] = useState(mockCapacity);
+
+  const handleFilesSelected = useCallback(
+    (files: File[]) => {
+      const currentCount = uploadFiles.length;
+      const remaining = MAX_FILES_PER_BATCH - currentCount;
+
+      if (remaining <= 0) {
+        toast.error(`최대 ${MAX_FILES_PER_BATCH}개까지 업로드할 수 있습니다.`);
+        return;
+      }
+
+      const filesToAdd = files.slice(0, remaining);
+      if (files.length > remaining) {
+        toast.warning(
+          `최대 ${MAX_FILES_PER_BATCH}개까지만 추가됩니다. ${files.length - remaining}개 파일이 제외되었습니다.`
+        );
+      }
+
+      const newUploadFiles: UploadFile[] = filesToAdd.map((file, i) => ({
+        id: `upload-${Date.now()}-${i}`,
+        file,
+        name: file.name,
+        originalName: file.name,
+        size: file.size,
+        uploadStatus: "pending" as const,
+        learningStatus: "idle" as const,
+      }));
+
+      setUploadFiles((prev) => [...prev, ...newUploadFiles]);
+      setMode("uploading");
+
+      // Simulate per-file upload
+      newUploadFiles.forEach((uf) => {
+        simulateUpload(uf.id).then((result) => {
+          setUploadFiles((prev) =>
+            prev.map((f) =>
+              f.id === uf.id
+                ? {
+                    ...f,
+                    uploadStatus: result === "success" ? "uploaded" : "error",
+                  }
+                : f
+            )
+          );
+        });
+      });
+
+      // Check when all uploads are done
+      const checkInterval = setInterval(() => {
+        setUploadFiles((prev) => {
+          const allDone = prev.every(
+            (f) => f.uploadStatus === "uploaded" || f.uploadStatus === "error"
+          );
+          if (allDone && prev.length > 0) {
+            clearInterval(checkInterval);
+            setMode("file-selected");
+          }
+          return prev;
+        });
+      }, 300);
+    },
+    [uploadFiles.length]
+  );
+
+  const handleRemoveUploadFile = useCallback((id: string) => {
+    setUploadFiles((prev) => {
+      const next = prev.filter((f) => f.id !== id);
+      if (next.length === 0) {
+        setMode("idle");
+      }
+      return next;
+    });
+  }, []);
+
+  const handleStartLearning = useCallback(() => {
+    setMode("learning");
+    setUploadFiles((prev) =>
+      prev.map((f) => ({ ...f, learningStatus: "learning" as const }))
+    );
+
+    uploadFiles
+      .filter((f) => f.uploadStatus === "uploaded")
+      .forEach((uf) => {
+        simulateLearning(uf.id).then((result) => {
+          setUploadFiles((prev) => {
+            const updated = prev.map((f) =>
+              f.id === uf.id ? { ...f, learningStatus: result } : f
+            );
+
+            const allDone = updated.every(
+              (f) =>
+                f.learningStatus === "completed" ||
+                f.learningStatus === "error"
+            );
+
+            if (allDone) {
+              const hasError = updated.some(
+                (f) => f.learningStatus === "error"
+              );
+              setTimeout(() => {
+                setMode(hasError ? "learn-error" : "learn-success");
+              }, 500);
+            }
+
+            return updated;
+          });
+        });
+      });
+  }, [uploadFiles]);
+
+  const handleLearningComplete = useCallback(() => {
+    const newCompleted: CompletedFile[] = uploadFiles
+      .filter((f) => f.learningStatus === "completed")
+      .map((f) => ({
+        id: f.id,
+        name: f.name,
+        originalName: f.originalName,
+        type: f.originalName.split(".").pop() ?? "unknown",
+        size: f.size,
+        uploadedAt: new Date().toISOString(),
+        weekNumber: parseInt(recordId) || 1,
+      }));
+
+    setCompletedFiles((prev) => [...prev, ...newCompleted]);
+    setCapacity((prev) => ({
+      ...prev,
+      usedBytes:
+        prev.usedBytes + newCompleted.reduce((sum, f) => sum + f.size, 0),
+    }));
+    setUploadFiles([]);
+    setMode("idle");
+    toast.success("학습이 완료되었습니다.");
+  }, [uploadFiles, recordId]);
+
+  const handleRetryLearning = useCallback(() => {
+    setUploadFiles((prev) =>
+      prev
+        .filter((f) => f.learningStatus === "error")
+        .map((f) => ({ ...f, learningStatus: "learning" as const }))
+    );
+    setMode("learning");
+
+    uploadFiles
+      .filter((f) => f.learningStatus === "error")
+      .forEach((uf) => {
+        simulateLearning(uf.id).then((result) => {
+          setUploadFiles((prev) => {
+            const updated = prev.map((f) =>
+              f.id === uf.id ? { ...f, learningStatus: result } : f
+            );
+
+            const allDone = updated.every(
+              (f) =>
+                f.learningStatus === "completed" ||
+                f.learningStatus === "error"
+            );
+
+            if (allDone) {
+              const hasError = updated.some(
+                (f) => f.learningStatus === "error"
+              );
+              setTimeout(() => {
+                setMode(hasError ? "learn-error" : "learn-success");
+              }, 500);
+            }
+
+            return updated;
+          });
+        });
+      });
+  }, [uploadFiles]);
+
+  const handleCancelUpload = useCallback(() => {
+    setUploadFiles([]);
+    setMode("idle");
+  }, []);
+
+  const handleDeleteFiles = useCallback(
+    async (fileIds: string[]) => {
+      await simulateDelete(fileIds);
+      const deletedSet = new Set(fileIds);
+      const deletedFiles = completedFiles.filter((f) => deletedSet.has(f.id));
+      setCompletedFiles((prev) => prev.filter((f) => !deletedSet.has(f.id)));
+      setCapacity((prev) => ({
+        ...prev,
+        usedBytes:
+          prev.usedBytes - deletedFiles.reduce((sum, f) => sum + f.size, 0),
+      }));
+      setMode("idle");
+      toast.success(`${fileIds.length}개 파일이 삭제되었습니다.`);
+    },
+    [completedFiles]
+  );
+
+  const handleMoveNavigate = useCallback(
+    (fileIds: string[]) => {
+      const params = new URLSearchParams();
+      params.set("files", fileIds.join(","));
+      router.push(
+        `/subjects/${subjectId}/records/${recordId}/manage/move?${params.toString()}`
+      );
+    },
+    [router, subjectId, recordId]
+  );
+
+  const handleFileTap = useCallback((file: CompletedFile) => {
+    console.log("File tapped:", file);
+  }, []);
+
+  const hasUploadedFiles = uploadFiles.some(
+    (f) => f.uploadStatus === "uploaded"
+  );
+
+  return (
+    <AppShell title={breadcrumb} showBack>
+      <div className="flex flex-col gap-4 p-4">
+        <CapacityIndicator
+          usedBytes={capacity.usedBytes}
+          maxBytes={capacity.maxBytes}
+        />
+
+        {/* Idle: show completed files + upload zone */}
+        {mode === "idle" && (
+          <>
+            <CompletedFileList
+              files={completedFiles}
+              onEdit={() => setMode("editing")}
+              onFileTap={handleFileTap}
+            />
+            <FileUploadZone onFilesSelected={handleFilesSelected} />
+          </>
+        )}
+
+        {/* File selected / Uploading */}
+        {(mode === "file-selected" || mode === "uploading") && (
+          <>
+            {completedFiles.length > 0 && (
+              <CompletedFileList
+                files={completedFiles}
+                onEdit={() => setMode("editing")}
+                onFileTap={handleFileTap}
+              />
+            )}
+            <UploadFileList
+              files={uploadFiles}
+              onRemove={handleRemoveUploadFile}
+            />
+            <FileUploadZone
+              compact
+              onFilesSelected={handleFilesSelected}
+              maxFiles={MAX_FILES_PER_BATCH}
+              currentFileCount={uploadFiles.length}
+            />
+            <Button
+              onClick={handleStartLearning}
+              disabled={!hasUploadedFiles || mode === "uploading"}
+              className="h-12 w-full rounded-xl text-base font-medium"
+            >
+              인공지능 학습시키기
+            </Button>
+          </>
+        )}
+
+        {/* AI Learning in progress */}
+        {mode === "learning" && <AiLearningStatus files={uploadFiles} />}
+
+        {/* Learning complete */}
+        {mode === "learn-success" && (
+          <LearningCompleteView onComplete={handleLearningComplete} />
+        )}
+
+        {/* Learning error */}
+        {mode === "learn-error" && (
+          <LearningErrorView
+            files={uploadFiles}
+            onRetry={handleRetryLearning}
+            onCancel={handleCancelUpload}
+          />
+        )}
+
+        {/* Edit mode */}
+        {mode === "editing" && (
+          <EditModeView
+            files={completedFiles}
+            onCancel={() => setMode("idle")}
+            onDelete={handleDeleteFiles}
+            onMoveNavigate={handleMoveNavigate}
+          />
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
@@ -263,17 +263,20 @@ export default function ManagePage({
     async (fileIds: string[]) => {
       await simulateDelete(fileIds);
       const deletedSet = new Set(fileIds);
-      const deletedFiles = completedFiles.filter((f) => deletedSet.has(f.id));
-      setCompletedFiles((prev) => prev.filter((f) => !deletedSet.has(f.id)));
+      let deletedBytes = 0;
+      setCompletedFiles((prev) => {
+        const deletedFiles = prev.filter((f) => deletedSet.has(f.id));
+        deletedBytes = deletedFiles.reduce((sum, f) => sum + f.size, 0);
+        return prev.filter((f) => !deletedSet.has(f.id));
+      });
       setCapacity((prev) => ({
         ...prev,
-        usedBytes:
-          prev.usedBytes - deletedFiles.reduce((sum, f) => sum + f.size, 0),
+        usedBytes: prev.usedBytes - deletedBytes,
       }));
       setMode("idle");
       toast.success(`${fileIds.length}개 파일이 삭제되었습니다.`);
     },
-    [completedFiles]
+    []
   );
 
   const handleMoveNavigate = useCallback(

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
@@ -216,9 +216,11 @@ export default function ManagePage({
 
   const handleRetryLearning = useCallback(() => {
     setUploadFiles((prev) =>
-      prev
-        .filter((f) => f.learningStatus === "error")
-        .map((f) => ({ ...f, learningStatus: "learning" as const }))
+      prev.map((f) =>
+        f.learningStatus === "error"
+          ? { ...f, learningStatus: "learning" as const }
+          : f
+      )
     );
     setMode("learning");
 

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState, useCallback } from "react";
+import { use, useState, useCallback, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { AppShell } from "@/app/_components/layout/AppShell";
 import { Button } from "@/app/_components/ui/button";
@@ -60,6 +60,13 @@ export default function ManagePage({
     useState<CompletedFile[]>(mockCompletedFiles);
   const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([]);
   const [capacity, setCapacity] = useState(mockCapacity);
+  const uploadCheckRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (uploadCheckRef.current) clearInterval(uploadCheckRef.current);
+    };
+  }, []);
 
   const handleFilesSelected = useCallback(
     (files: File[]) => {
@@ -108,13 +115,20 @@ export default function ManagePage({
       });
 
       // Check when all uploads are done
-      const checkInterval = setInterval(() => {
+      if (uploadCheckRef.current) clearInterval(uploadCheckRef.current);
+      uploadCheckRef.current = setInterval(() => {
         setUploadFiles((prev) => {
+          if (prev.length === 0) {
+            clearInterval(uploadCheckRef.current!);
+            uploadCheckRef.current = null;
+            return prev;
+          }
           const allDone = prev.every(
             (f) => f.uploadStatus === "uploaded" || f.uploadStatus === "error"
           );
-          if (allDone && prev.length > 0) {
-            clearInterval(checkInterval);
+          if (allDone) {
+            clearInterval(uploadCheckRef.current!);
+            uploadCheckRef.current = null;
             setMode("file-selected");
           }
           return prev;

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/manage/page.tsx
@@ -151,7 +151,13 @@ export default function ManagePage({
   const handleStartLearning = useCallback(() => {
     setMode("learning");
     setUploadFiles((prev) =>
-      prev.map((f) => ({ ...f, learningStatus: "learning" as const }))
+      prev.map((f) => ({
+        ...f,
+        learningStatus:
+          f.uploadStatus === "uploaded"
+            ? ("learning" as const)
+            : ("error" as const),
+      }))
     );
 
     uploadFiles

--- a/app/(main)/subjects/[subjectId]/records/[recordId]/page.tsx
+++ b/app/(main)/subjects/[subjectId]/records/[recordId]/page.tsx
@@ -31,7 +31,7 @@ export default function RecordDetailPage({
   return (
     <AppShell title={breadcrumb} showBack>
       <div className="flex flex-col gap-4 p-4">
-        <FeatureCardGrid />
+        <FeatureCardGrid subjectId={subjectId} recordId={recordId} />
         <RecordContent />
       </div>
     </AppShell>

--- a/app/_components/pages/manage/AiLearningStatus.tsx
+++ b/app/_components/pages/manage/AiLearningStatus.tsx
@@ -1,0 +1,35 @@
+import { Bot } from "lucide-react";
+import type { UploadFile } from "@/app/_lib/mock/manage-types";
+import { LearningFileItem } from "./LearningFileItem";
+
+type AiLearningStatusProps = {
+  files: UploadFile[];
+};
+
+export function AiLearningStatus({ files }: AiLearningStatusProps) {
+  const completedCount = files.filter(
+    (f) => f.learningStatus === "completed"
+  ).length;
+  const totalCount = files.length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col items-center gap-3 py-4">
+        <div className="flex size-14 items-center justify-center rounded-2xl bg-[#648AD7]/10">
+          <Bot className="size-7 text-[#648AD7]" />
+        </div>
+        <p className="text-center text-sm font-medium text-foreground">
+          인공지능이 업로드하신 파일을 학습하는 중이에요
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {completedCount}/{totalCount} 완료
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        {files.map((file) => (
+          <LearningFileItem key={file.id} file={file} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/_components/pages/manage/CapacityIndicator.tsx
+++ b/app/_components/pages/manage/CapacityIndicator.tsx
@@ -15,7 +15,8 @@ export function CapacityIndicator({
   usedBytes,
   maxBytes,
 }: CapacityIndicatorProps) {
-  const percentage = Math.min((usedBytes / maxBytes) * 100, 100);
+  const percentage =
+    maxBytes > 0 ? Math.min((usedBytes / maxBytes) * 100, 100) : 0;
 
   return (
     <div className="flex items-center justify-between px-1">

--- a/app/_components/pages/manage/CapacityIndicator.tsx
+++ b/app/_components/pages/manage/CapacityIndicator.tsx
@@ -1,0 +1,33 @@
+type CapacityIndicatorProps = {
+  usedBytes: number;
+  maxBytes: number;
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GB`;
+}
+
+export function CapacityIndicator({
+  usedBytes,
+  maxBytes,
+}: CapacityIndicatorProps) {
+  const percentage = Math.min((usedBytes / maxBytes) * 100, 100);
+
+  return (
+    <div className="flex items-center justify-between px-1">
+      <span className="text-xs text-muted-foreground">
+        업로드 가능 용량: {formatBytes(usedBytes)} / {formatBytes(maxBytes)}
+      </span>
+      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-all duration-300"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/_components/pages/manage/CompletedFileItem.tsx
+++ b/app/_components/pages/manage/CompletedFileItem.tsx
@@ -1,0 +1,26 @@
+import { ChevronRight } from "lucide-react";
+import type { CompletedFile } from "@/app/_lib/mock/manage-types";
+
+type CompletedFileItemProps = {
+  file: CompletedFile;
+  onTap: (file: CompletedFile) => void;
+};
+
+function truncateName(name: string, max: number = 20): string {
+  if (name.length <= max) return name;
+  return name.slice(0, max - 3) + "...";
+}
+
+export function CompletedFileItem({ file, onTap }: CompletedFileItemProps) {
+  return (
+    <button
+      onClick={() => onTap(file)}
+      className="flex min-h-[44px] w-full items-center justify-between rounded-xl bg-card px-4 py-3 ring-1 ring-foreground/10 transition-all duration-150 hover:bg-accent active:scale-[0.98]"
+    >
+      <span className="truncate text-sm font-medium text-foreground">
+        {truncateName(file.originalName)}
+      </span>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+    </button>
+  );
+}

--- a/app/_components/pages/manage/CompletedFileList.tsx
+++ b/app/_components/pages/manage/CompletedFileList.tsx
@@ -1,0 +1,39 @@
+import type { CompletedFile } from "@/app/_lib/mock/manage-types";
+import { CompletedFileItem } from "./CompletedFileItem";
+
+type CompletedFileListProps = {
+  files: CompletedFile[];
+  onEdit: () => void;
+  onFileTap: (file: CompletedFile) => void;
+};
+
+export function CompletedFileList({
+  files,
+  onEdit,
+  onFileTap,
+}: CompletedFileListProps) {
+  if (files.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between px-1">
+        <h3 className="text-sm font-bold text-foreground">
+          학습 완료 파일 목록
+        </h3>
+        <button
+          onClick={onEdit}
+          className="text-xs font-medium text-primary transition-colors hover:text-primary/80"
+        >
+          편집
+        </button>
+      </div>
+      <div className="-mx-1 max-h-[176px] overflow-y-auto px-1 py-0.5">
+        <div className="flex flex-col gap-2">
+          {files.map((file) => (
+            <CompletedFileItem key={file.id} file={file} onTap={onFileTap} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/_components/pages/manage/EditModeView.tsx
+++ b/app/_components/pages/manage/EditModeView.tsx
@@ -59,6 +59,7 @@ export function EditModeView({
               <button
                 key={file.id}
                 onClick={() => toggleSelect(file.id)}
+                aria-pressed={isSelected}
                 className={[
                   "flex min-h-[44px] w-full items-center gap-3 rounded-xl px-4 py-3 ring-1 transition-all duration-150",
                   isSelected

--- a/app/_components/pages/manage/EditModeView.tsx
+++ b/app/_components/pages/manage/EditModeView.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Check } from "lucide-react";
+import { Button } from "@/app/_components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/app/_components/ui/alert-dialog";
+import type { CompletedFile } from "@/app/_lib/mock/manage-types";
+import { SelectionCounter } from "./SelectionCounter";
+
+type EditModeViewProps = {
+  files: CompletedFile[];
+  onCancel: () => void;
+  onDelete: (fileIds: string[]) => void;
+  onMoveNavigate: (fileIds: string[]) => void;
+};
+
+export function EditModeView({
+  files,
+  onCancel,
+  onDelete,
+  onMoveNavigate,
+}: EditModeViewProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const selectedArray = Array.from(selectedIds);
+  const hasSelection = selectedIds.size > 0;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between px-1">
+        <h3 className="text-sm font-bold text-foreground">파일 관리</h3>
+        <SelectionCounter selected={selectedIds.size} total={files.length} />
+      </div>
+
+      <div className="-mx-1 max-h-[260px] overflow-y-auto px-1 py-0.5">
+        <div className="flex flex-col gap-2">
+          {files.map((file) => {
+            const isSelected = selectedIds.has(file.id);
+            return (
+              <button
+                key={file.id}
+                onClick={() => toggleSelect(file.id)}
+                className={[
+                  "flex min-h-[44px] w-full items-center gap-3 rounded-xl px-4 py-3 ring-1 transition-all duration-150",
+                  isSelected
+                    ? "bg-primary/5 ring-primary/30"
+                    : "bg-card ring-foreground/10 hover:bg-accent",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+              >
+                <div
+                  className={[
+                    "flex size-5 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-150",
+                    isSelected
+                      ? "border-primary bg-primary"
+                      : "border-muted-foreground/30",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
+                  {isSelected && <Check className="size-3 text-white" />}
+                </div>
+                <span className="truncate text-sm font-medium text-foreground">
+                  {file.originalName.length > 20
+                    ? file.originalName.slice(0, 17) + "..."
+                    : file.originalName}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 pt-2">
+        <div className="flex gap-2">
+          <AlertDialog>
+            <AlertDialogTrigger
+              disabled={!hasSelection}
+              render={
+                <Button
+                  variant="destructive"
+                  className="h-12 flex-1 rounded-xl text-base font-medium"
+                  disabled={!hasSelection}
+                />
+              }
+            >
+              파일 삭제
+            </AlertDialogTrigger>
+            <AlertDialogContent size="sm">
+              <AlertDialogHeader>
+                <AlertDialogTitle>파일 삭제</AlertDialogTitle>
+                <AlertDialogDescription>
+                  선택한 {selectedIds.size}개의 파일을 삭제하시겠습니까? 이 작업은
+                  되돌릴 수 없습니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  onClick={() => onDelete(selectedArray)}
+                >
+                  삭제
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <Button
+            variant="outline"
+            disabled={!hasSelection}
+            onClick={() => onMoveNavigate(selectedArray)}
+            className="h-12 flex-1 rounded-xl text-base font-medium"
+          >
+            폴더 이동
+          </Button>
+        </div>
+
+        <Button
+          variant="ghost"
+          onClick={onCancel}
+          className="h-12 w-full rounded-xl text-base font-medium"
+        >
+          취소
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/_components/pages/manage/FileUploadZone.tsx
+++ b/app/_components/pages/manage/FileUploadZone.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { Plus } from "lucide-react";
 
 const ACCEPTED_TYPES = ".pdf,.doc,.docx,.ppt,.pptx";
+const ACCEPTED_EXTENSIONS = ACCEPTED_TYPES.split(",");
 
 type FileUploadZoneProps = {
   onFilesSelected: (files: File[]) => void;
@@ -23,8 +24,14 @@ export function FileUploadZone({
 
   function handleFiles(fileList: FileList | null) {
     if (!fileList) return;
-    const remaining = maxFiles - currentFileCount;
-    const files = Array.from(fileList).slice(0, remaining);
+    const remaining = Math.max(0, maxFiles - currentFileCount);
+    const files = Array.from(fileList)
+      .filter((file) =>
+        ACCEPTED_EXTENSIONS.some((ext) =>
+          file.name.toLowerCase().endsWith(ext),
+        ),
+      )
+      .slice(0, remaining);
     if (files.length > 0) {
       onFilesSelected(files);
     }

--- a/app/_components/pages/manage/FileUploadZone.tsx
+++ b/app/_components/pages/manage/FileUploadZone.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Plus } from "lucide-react";
+
+const ACCEPTED_TYPES = ".pdf,.doc,.docx,.ppt,.pptx";
+
+type FileUploadZoneProps = {
+  onFilesSelected: (files: File[]) => void;
+  compact?: boolean;
+  maxFiles?: number;
+  currentFileCount?: number;
+};
+
+export function FileUploadZone({
+  onFilesSelected,
+  compact = false,
+  maxFiles = 5,
+  currentFileCount = 0,
+}: FileUploadZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  function handleFiles(fileList: FileList | null) {
+    if (!fileList) return;
+    const remaining = maxFiles - currentFileCount;
+    const files = Array.from(fileList).slice(0, remaining);
+    if (files.length > 0) {
+      onFilesSelected(files);
+    }
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+    handleFiles(e.dataTransfer.files);
+  }
+
+  if (compact) {
+    return (
+      <>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED_TYPES}
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            handleFiles(e.target.files);
+            e.target.value = "";
+          }}
+        />
+        <button
+          onClick={() => inputRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          className={[
+            "flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed py-3 text-sm font-medium transition-all duration-200",
+            isDragging
+              ? "border-primary bg-primary/5 text-primary"
+              : "border-border text-muted-foreground hover:border-primary/50 hover:text-primary",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <Plus className="size-4" />
+          추가 업로드
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPTED_TYPES}
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          handleFiles(e.target.files);
+          e.target.value = "";
+        }}
+      />
+      <button
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+        className={[
+          "flex w-full flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed py-12 transition-all duration-200",
+          isDragging
+            ? "border-primary bg-primary/5"
+            : "border-border hover:border-primary/50",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        <div className="flex size-14 items-center justify-center rounded-2xl bg-muted">
+          <Plus className="size-7 text-muted-foreground" />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          파일을 업로드하여 공부를 시작해보세요!
+        </p>
+        <p className="text-xs text-muted-foreground/60">
+          PDF, DOC, DOCX, PPT, PPTX
+        </p>
+      </button>
+    </>
+  );
+}

--- a/app/_components/pages/manage/LearningCompleteView.tsx
+++ b/app/_components/pages/manage/LearningCompleteView.tsx
@@ -1,0 +1,30 @@
+import { Bot, CheckCircle2 } from "lucide-react";
+import { Button } from "@/app/_components/ui/button";
+
+type LearningCompleteViewProps = {
+  onComplete: () => void;
+};
+
+export function LearningCompleteView({
+  onComplete,
+}: LearningCompleteViewProps) {
+  return (
+    <div className="flex flex-col items-center gap-6 py-8">
+      <div className="relative">
+        <div className="flex size-16 items-center justify-center rounded-2xl bg-[#53BE4F]/10">
+          <Bot className="size-8 text-[#53BE4F]" />
+        </div>
+        <CheckCircle2 className="absolute -right-1 -bottom-1 size-6 text-[#53BE4F]" />
+      </div>
+      <p className="text-center text-sm font-medium text-foreground">
+        인공지능이 업로드하신 파일을 학습 완료하였습니다
+      </p>
+      <Button
+        onClick={onComplete}
+        className="h-12 w-full rounded-xl text-base font-medium"
+      >
+        완료
+      </Button>
+    </div>
+  );
+}

--- a/app/_components/pages/manage/LearningErrorView.tsx
+++ b/app/_components/pages/manage/LearningErrorView.tsx
@@ -1,0 +1,56 @@
+import { Bot, XCircle } from "lucide-react";
+import { Button } from "@/app/_components/ui/button";
+import type { UploadFile } from "@/app/_lib/mock/manage-types";
+import { LearningFileItem } from "./LearningFileItem";
+
+type LearningErrorViewProps = {
+  files: UploadFile[];
+  onRetry: () => void;
+  onCancel: () => void;
+};
+
+export function LearningErrorView({
+  files,
+  onRetry,
+  onCancel,
+}: LearningErrorViewProps) {
+  const errorFiles = files.filter((f) => f.learningStatus === "error");
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col items-center gap-3 py-4">
+        <div className="relative">
+          <div className="flex size-16 items-center justify-center rounded-2xl bg-destructive/10">
+            <Bot className="size-8 text-destructive" />
+          </div>
+          <XCircle className="absolute -right-1 -bottom-1 size-6 text-destructive" />
+        </div>
+        <p className="text-center text-sm font-medium text-foreground">
+          파일을 학습하는 중 오류가 발생했습니다
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {errorFiles.map((file) => (
+          <LearningFileItem key={file.id} file={file} />
+        ))}
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          className="h-12 flex-1 rounded-xl text-base font-medium"
+        >
+          업로드 취소
+        </Button>
+        <Button
+          onClick={onRetry}
+          className="h-12 flex-1 rounded-xl text-base font-medium"
+        >
+          다시 시도
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/_components/pages/manage/LearningFileItem.tsx
+++ b/app/_components/pages/manage/LearningFileItem.tsx
@@ -1,0 +1,52 @@
+import { Loader2, Check } from "lucide-react";
+import type { UploadFile } from "@/app/_lib/mock/manage-types";
+
+type LearningFileItemProps = {
+  file: UploadFile;
+};
+
+function truncateName(name: string, max: number = 20): string {
+  if (name.length <= max) return name;
+  const ext = name.lastIndexOf(".");
+  if (ext > 0) {
+    const base = name.slice(0, ext);
+    const extension = name.slice(ext);
+    const truncated = base.slice(0, max - 3 - extension.length);
+    return `${truncated}...${extension}`;
+  }
+  return name.slice(0, max - 3) + "...";
+}
+
+export function LearningFileItem({ file }: LearningFileItemProps) {
+  const isCompleted = file.learningStatus === "completed";
+  const isError = file.learningStatus === "error";
+
+  const bgColor = isCompleted
+    ? "bg-[#53BE4F]/10 ring-[#53BE4F]/20"
+    : isError
+      ? "bg-destructive/10 ring-destructive/20"
+      : "bg-[#648AD7]/10 ring-[#648AD7]/20";
+
+  const textColor = isCompleted
+    ? "text-[#53BE4F]"
+    : isError
+      ? "text-destructive"
+      : "text-[#648AD7]";
+
+  return (
+    <div
+      className={`flex min-h-[44px] items-center justify-between rounded-xl px-4 py-3 ring-1 transition-all duration-300 ${bgColor}`}
+    >
+      <span className={`truncate text-sm font-medium ${textColor}`}>
+        {truncateName(file.originalName)}
+      </span>
+      {isCompleted ? (
+        <Check className="size-4 shrink-0 text-[#53BE4F]" />
+      ) : isError ? (
+        <span className="text-xs font-medium text-destructive">오류</span>
+      ) : (
+        <Loader2 className="size-4 shrink-0 animate-spin text-[#648AD7]" />
+      )}
+    </div>
+  );
+}

--- a/app/_components/pages/manage/SelectionCounter.tsx
+++ b/app/_components/pages/manage/SelectionCounter.tsx
@@ -1,0 +1,13 @@
+type SelectionCounterProps = {
+  selected: number;
+  total: number;
+};
+
+export function SelectionCounter({ selected, total }: SelectionCounterProps) {
+  return (
+    <p className="text-center text-sm text-muted-foreground">
+      <span className="font-bold text-foreground">{selected}개</span>/{total}개
+      선택중
+    </p>
+  );
+}

--- a/app/_components/pages/manage/UploadFileItem.tsx
+++ b/app/_components/pages/manage/UploadFileItem.tsx
@@ -33,6 +33,7 @@ export function UploadFileItem({ file, onRemove }: UploadFileItemProps) {
       ) : (
         <button
           onClick={() => onRemove(file.id)}
+          aria-label={`${file.originalName} 삭제`}
           className="flex size-6 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-muted"
         >
           <X className="size-4 text-muted-foreground" />

--- a/app/_components/pages/manage/UploadFileItem.tsx
+++ b/app/_components/pages/manage/UploadFileItem.tsx
@@ -12,8 +12,9 @@ function truncateName(name: string, max: number = 15): string {
   if (ext > 0) {
     const base = name.slice(0, ext);
     const extension = name.slice(ext);
-    const truncated = base.slice(0, max - 3 - extension.length);
-    return `${truncated}...${extension}`;
+    const available = Math.max(0, max - 3 - extension.length);
+    if (available === 0) return `...${extension}`;
+    return `${base.slice(0, available)}...${extension}`;
   }
   return name.slice(0, max - 3) + "...";
 }

--- a/app/_components/pages/manage/UploadFileItem.tsx
+++ b/app/_components/pages/manage/UploadFileItem.tsx
@@ -1,0 +1,42 @@
+import { Loader2, X } from "lucide-react";
+import type { UploadFile } from "@/app/_lib/mock/manage-types";
+
+type UploadFileItemProps = {
+  file: UploadFile;
+  onRemove: (id: string) => void;
+};
+
+function truncateName(name: string, max: number = 15): string {
+  if (name.length <= max) return name;
+  const ext = name.lastIndexOf(".");
+  if (ext > 0) {
+    const base = name.slice(0, ext);
+    const extension = name.slice(ext);
+    const truncated = base.slice(0, max - 3 - extension.length);
+    return `${truncated}...${extension}`;
+  }
+  return name.slice(0, max - 3) + "...";
+}
+
+export function UploadFileItem({ file, onRemove }: UploadFileItemProps) {
+  const isUploading =
+    file.uploadStatus === "pending" || file.uploadStatus === "uploading";
+
+  return (
+    <div className="flex min-h-[44px] items-center justify-between rounded-xl bg-card px-4 py-3 ring-1 ring-foreground/10 transition-all duration-200">
+      <span className="truncate text-sm font-medium text-foreground">
+        {truncateName(file.originalName)}
+      </span>
+      {isUploading ? (
+        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+      ) : (
+        <button
+          onClick={() => onRemove(file.id)}
+          className="flex size-6 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-muted"
+        >
+          <X className="size-4 text-muted-foreground" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/_components/pages/manage/UploadFileList.tsx
+++ b/app/_components/pages/manage/UploadFileList.tsx
@@ -1,0 +1,19 @@
+import type { UploadFile } from "@/app/_lib/mock/manage-types";
+import { UploadFileItem } from "./UploadFileItem";
+
+type UploadFileListProps = {
+  files: UploadFile[];
+  onRemove: (id: string) => void;
+};
+
+export function UploadFileList({ files, onRemove }: UploadFileListProps) {
+  if (files.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {files.map((file) => (
+        <UploadFileItem key={file.id} file={file} onRemove={onRemove} />
+      ))}
+    </div>
+  );
+}

--- a/app/_components/pages/manage/move/FolderList.tsx
+++ b/app/_components/pages/manage/move/FolderList.tsx
@@ -1,0 +1,39 @@
+import { ChevronRight } from "lucide-react";
+import type { WeekFolder } from "@/app/_lib/mock/manage-types";
+
+type FolderListProps = {
+  folders: WeekFolder[];
+  onSelect: (folder: WeekFolder) => void;
+};
+
+export function FolderList({ folders, onSelect }: FolderListProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {folders.map((folder) => (
+        <button
+          key={folder.recordId}
+          onClick={() => !folder.isCurrent && onSelect(folder)}
+          disabled={folder.isCurrent}
+          className={[
+            "flex min-h-[44px] w-full items-center justify-between rounded-xl px-4 py-3 ring-1 transition-all duration-150",
+            folder.isCurrent
+              ? "cursor-not-allowed bg-muted/50 opacity-40 ring-foreground/5"
+              : "bg-card ring-foreground/10 hover:bg-accent active:scale-[0.98]",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <span className="text-sm font-medium text-foreground">
+            {folder.label}
+          </span>
+          {!folder.isCurrent && (
+            <ChevronRight className="size-4 text-muted-foreground" />
+          )}
+          {folder.isCurrent && (
+            <span className="text-xs text-muted-foreground">현재 폴더</span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/_components/pages/manage/move/MoveConfirmDialog.tsx
+++ b/app/_components/pages/manage/move/MoveConfirmDialog.tsx
@@ -32,8 +32,11 @@ export function MoveConfirmDialog({
 
   async function handleConfirm() {
     setIsLoading(true);
-    await onConfirm();
-    setIsLoading(false);
+    try {
+      await onConfirm();
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   return (

--- a/app/_components/pages/manage/move/MoveConfirmDialog.tsx
+++ b/app/_components/pages/manage/move/MoveConfirmDialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/app/_components/ui/alert-dialog";
+
+type MoveConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentWeek: number;
+  targetWeek: number;
+  onConfirm: () => Promise<void>;
+};
+
+export function MoveConfirmDialog({
+  open,
+  onOpenChange,
+  currentWeek,
+  targetWeek,
+  onConfirm,
+}: MoveConfirmDialogProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleConfirm() {
+    setIsLoading(true);
+    await onConfirm();
+    setIsLoading(false);
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {currentWeek}주차 &gt; {targetWeek}주차
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            컨텐츠를 이동하시겠어요?
+            <br />
+            현재 폴더의 파일이 삭제되고,
+            <br />
+            선택한 폴더에 파일이 추가됩니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>취소</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm} disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                이동 중...
+              </>
+            ) : (
+              "이동"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/_components/pages/records/FeatureCardGrid.tsx
+++ b/app/_components/pages/records/FeatureCardGrid.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   FileText,
   BookOpen,
@@ -11,38 +12,49 @@ type FeatureCard = {
   label: string;
   icon: React.ReactNode;
   color: string;
+  href?: string;
 };
 
-const topCards: FeatureCard[] = [
-  {
-    label: "문제풀기",
-    icon: <FileText className="size-6" />,
-    color: "bg-primary/10 text-primary",
-  },
-  {
-    label: "요약노트",
-    icon: <BookOpen className="size-6" />,
-    color: "bg-chart-2/15 text-chart-2",
-  },
-];
+type FeatureCardGridProps = {
+  subjectId: string;
+  recordId: string;
+};
 
-const bottomCards: FeatureCard[] = [
-  {
-    label: "파일관리",
-    icon: <FolderOpen className="size-5" />,
-    color: "bg-chart-3/15 text-chart-3",
-  },
-  {
-    label: "오답노트",
-    icon: <CircleX className="size-5" />,
-    color: "bg-destructive/10 text-destructive",
-  },
-  {
-    label: "북마크",
-    icon: <Bookmark className="size-5" />,
-    color: "bg-chart-4/15 text-chart-4",
-  },
-];
+function getTopCards(): FeatureCard[] {
+  return [
+    {
+      label: "문제풀기",
+      icon: <FileText className="size-6" />,
+      color: "bg-primary/10 text-primary",
+    },
+    {
+      label: "요약노트",
+      icon: <BookOpen className="size-6" />,
+      color: "bg-chart-2/15 text-chart-2",
+    },
+  ];
+}
+
+function getBottomCards(subjectId: string, recordId: string): FeatureCard[] {
+  return [
+    {
+      label: "파일관리",
+      icon: <FolderOpen className="size-5" />,
+      color: "bg-chart-3/15 text-chart-3",
+      href: `/subjects/${subjectId}/records/${recordId}/manage`,
+    },
+    {
+      label: "오답노트",
+      icon: <CircleX className="size-5" />,
+      color: "bg-destructive/10 text-destructive",
+    },
+    {
+      label: "북마크",
+      icon: <Bookmark className="size-5" />,
+      color: "bg-chart-4/15 text-chart-4",
+    },
+  ];
+}
 
 function FeatureCardItem({
   card,
@@ -51,13 +63,8 @@ function FeatureCardItem({
   card: FeatureCard;
   size: "lg" | "sm";
 }) {
-  return (
-    <button
-      className={cn(
-        "flex flex-col items-center justify-center gap-2 rounded-xl bg-card ring-1 ring-foreground/10 transition-all duration-150 active:scale-[0.97] hover:ring-foreground/20 hover:shadow-sm",
-        size === "lg" ? "py-6" : "py-4"
-      )}
-    >
+  const content = (
+    <>
       <div
         className={cn(
           "flex items-center justify-center rounded-lg",
@@ -75,11 +82,33 @@ function FeatureCardItem({
       >
         {card.label}
       </span>
+    </>
+  );
+
+  const className = cn(
+    "flex flex-col items-center justify-center gap-2 rounded-xl bg-card ring-1 ring-foreground/10 transition-all duration-150 active:scale-[0.97] hover:ring-foreground/20 hover:shadow-sm",
+    size === "lg" ? "py-6" : "py-4"
+  );
+
+  if (card.href) {
+    return (
+      <Link href={card.href} className={className}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button className={className}>
+      {content}
     </button>
   );
 }
 
-export function FeatureCardGrid() {
+export function FeatureCardGrid({ subjectId, recordId }: FeatureCardGridProps) {
+  const topCards = getTopCards();
+  const bottomCards = getBottomCards(subjectId, recordId);
+
   return (
     <div className="flex flex-col gap-2">
       <div className="grid grid-cols-2 gap-2">

--- a/app/_components/ui/alert-dialog.tsx
+++ b/app/_components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/app/_lib/utils"
+import { Button } from "@/app/_components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/app/_components/ui/button.tsx
+++ b/app/_components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/app/_lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/app/_components/ui/checkbox.tsx
+++ b/app/_components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+
+import { cn } from "@/app/_lib/utils"
+import { CheckIcon } from "lucide-react"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/app/_components/ui/dialog.tsx
+++ b/app/_components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/app/_lib/utils"
+import { Button } from "@/app/_components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/app/_components/ui/dialog.tsx
+++ b/app/_components/ui/dialog.tsx
@@ -51,33 +51,26 @@ function DialogContent({
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Popup
-        data-slot="dialog-content"
+        data-slot='dialog-content'
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
         )}
         {...props}
       >
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close
-            data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
+            data-slot='dialog-close'
+            render={<Button variant='ghost' className='absolute top-2 right-2' size='icon-sm' />}
           >
-            <XIcon
-            />
-            <span className="sr-only">Close</span>
+            <XIcon />
+            <span className='sr-only'>닫기</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -100,21 +93,17 @@ function DialogFooter({
 }) {
   return (
     <div
-      data-slot="dialog-footer"
+      data-slot='dialog-footer'
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+        className,
       )}
       {...props}
     >
       {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
-        </DialogPrimitive.Close>
-      )}
+      {showCloseButton && <DialogPrimitive.Close render={<Button variant='outline' />}>닫기</DialogPrimitive.Close>}
     </div>
-  )
+  );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {

--- a/app/_components/ui/progress.tsx
+++ b/app/_components/ui/progress.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+
+import { cn } from "@/app/_lib/utils"
+
+function Progress({
+  className,
+  children,
+  value,
+  ...props
+}: ProgressPrimitive.Root.Props) {
+  return (
+    <ProgressPrimitive.Root
+      value={value}
+      data-slot="progress"
+      className={cn("flex flex-wrap gap-3", className)}
+      {...props}
+    >
+      {children}
+      <ProgressTrack>
+        <ProgressIndicator />
+      </ProgressTrack>
+    </ProgressPrimitive.Root>
+  )
+}
+
+function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props) {
+  return (
+    <ProgressPrimitive.Track
+      className={cn(
+        "relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-muted",
+        className
+      )}
+      data-slot="progress-track"
+      {...props}
+    />
+  )
+}
+
+function ProgressIndicator({
+  className,
+  ...props
+}: ProgressPrimitive.Indicator.Props) {
+  return (
+    <ProgressPrimitive.Indicator
+      data-slot="progress-indicator"
+      className={cn("h-full bg-primary transition-all", className)}
+      {...props}
+    />
+  )
+}
+
+function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props) {
+  return (
+    <ProgressPrimitive.Label
+      className={cn("text-sm font-medium", className)}
+      data-slot="progress-label"
+      {...props}
+    />
+  )
+}
+
+function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props) {
+  return (
+    <ProgressPrimitive.Value
+      className={cn(
+        "ml-auto text-sm text-muted-foreground tabular-nums",
+        className
+      )}
+      data-slot="progress-value"
+      {...props}
+    />
+  )
+}
+
+export {
+  Progress,
+  ProgressTrack,
+  ProgressIndicator,
+  ProgressLabel,
+  ProgressValue,
+}

--- a/app/_components/ui/sonner.tsx
+++ b/app/_components/ui/sonner.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="light"
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/app/_lib/mock/manage-actions.ts
+++ b/app/_lib/mock/manage-actions.ts
@@ -1,0 +1,42 @@
+function randomDelay(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export async function simulateUpload(
+  _fileId: string
+): Promise<"success" | "error"> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(Math.random() > 0.05 ? "success" : "error");
+    }, randomDelay(1000, 2000));
+  });
+}
+
+export async function simulateLearning(
+  _fileId: string
+): Promise<"completed" | "error"> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(Math.random() > 0.2 ? "completed" : "error");
+    }, randomDelay(1000, 3000));
+  });
+}
+
+export async function simulateMove(
+  _fileIds: string[],
+  _targetWeek: number
+): Promise<"success" | "error"> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(Math.random() > 0.2 ? "success" : "error");
+    }, randomDelay(1000, 2000));
+  });
+}
+
+export async function simulateDelete(
+  _fileIds: string[]
+): Promise<"success"> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve("success"), 300);
+  });
+}

--- a/app/_lib/mock/manage-data.ts
+++ b/app/_lib/mock/manage-data.ts
@@ -1,0 +1,42 @@
+import type { CompletedFile, WeekFolder } from "./manage-types";
+
+export const mockCompletedFiles: CompletedFile[] = [
+  {
+    id: "1",
+    name: "AA.pdf",
+    originalName: "AA.pdf",
+    type: "pdf",
+    size: 1024000,
+    uploadedAt: "2025-03-20T09:00:00Z",
+    weekNumber: 2,
+  },
+  {
+    id: "2",
+    name: "BB.pdf",
+    originalName: "BB.pdf",
+    type: "pdf",
+    size: 2048000,
+    uploadedAt: "2025-03-21T10:30:00Z",
+    weekNumber: 2,
+  },
+  {
+    id: "3",
+    name: "CC.pdf",
+    originalName: "CC.pdf",
+    type: "pdf",
+    size: 512000,
+    uploadedAt: "2025-03-22T14:00:00Z",
+    weekNumber: 2,
+  },
+];
+
+export const mockWeekFolders: WeekFolder[] = [
+  { recordId: "rec-1", weekNumber: 1, label: "1주차", isCurrent: false },
+  { recordId: "rec-2", weekNumber: 2, label: "2주차", isCurrent: true },
+  { recordId: "rec-3", weekNumber: 3, label: "3주차", isCurrent: false },
+];
+
+export const mockCapacity = {
+  usedBytes: 2_966_528,
+  maxBytes: 1_610_612_736,
+};

--- a/app/_lib/mock/manage-types.ts
+++ b/app/_lib/mock/manage-types.ts
@@ -1,0 +1,35 @@
+export interface UploadFile {
+  id: string;
+  file: File;
+  name: string;
+  originalName: string;
+  size: number;
+  uploadStatus: "pending" | "uploading" | "uploaded" | "error";
+  learningStatus: "idle" | "learning" | "completed" | "error";
+}
+
+export interface CompletedFile {
+  id: string;
+  name: string;
+  originalName: string;
+  type: string;
+  size: number;
+  uploadedAt: string;
+  weekNumber: number;
+}
+
+export interface WeekFolder {
+  recordId: string;
+  weekNumber: number;
+  label: string;
+  isCurrent: boolean;
+}
+
+export type ManagePageMode =
+  | "idle"
+  | "file-selected"
+  | "uploading"
+  | "learning"
+  | "learn-success"
+  | "learn-error"
+  | "editing";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist_Mono } from 'next/font/google';
+import { Toaster } from "@/app/_components/ui/sonner";
 import "./globals.css";
 
 const geistMono = Geist_Mono({
@@ -19,7 +20,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-      <body className={`${geistMono.variable} antialiased`}>{children}</body>
+      <body className={`${geistMono.variable} antialiased`}>
+        {children}
+        <Toaster position="top-center" duration={3000} />
+      </body>
     </html>
   );
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "^15.5.7",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "shadcn": "^4.0.8",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3472,6 +3472,11 @@ negotiator@^1.0.0:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
+next-themes@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.4.6.tgz#8d7e92d03b8fea6582892a50a928c9b23502e8b6"
+  integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
+
 next@^15.5.7:
   version "15.5.7"
   resolved "https://registry.yarnpkg.com/next/-/next-15.5.7.tgz#4507700b2bbcaf2c9fb7a9ad25c0dac2ba4a9a75"
@@ -4276,6 +4281,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## 이슈
- #1 

## ✔️  체크리스트
- [x] : Merge할 브랜치를 확인해 주세요.

## 🔍 작업 내용
**파일관리 페이지 UI 및 상태 머신을 구현하였습니다.**

- 파일 업로드, 처리 중, 완료, 에러 각 단계에 대응하는 컴포넌트를 구현하였습니다.
  - [`FileUploadZone`](app/_components/pages/manage/FileUploadZone.tsx)
  - [`UploadFileItem`](app/_components/pages/manage/UploadFileItem.tsx) / [`UploadFileList`](app/_components/pages/manage/UploadFileList.tsx)
  - [`LearningFileItem`](app/_components/pages/manage/LearningFileItem.tsx)
  - [`CompletedFileItem`](app/_components/pages/manage/CompletedFileItem.tsx) / [`CompletedFileList`](app/_components/pages/manage/CompletedFileList.tsx)
  - [`LearningCompleteView`](app/_components/pages/manage/LearningCompleteView.tsx) / [`LearningErrorView`](app/_components/pages/manage/LearningErrorView.tsx)
  - [`AiLearningStatus`](app/_components/pages/manage/AiLearningStatus.tsx) / [`CapacityIndicator`](app/_components/pages/manage/CapacityIndicator.tsx)
  - [`EditModeView`](app/_components/pages/manage/EditModeView.tsx) / [`SelectionCounter`](app/_components/pages/manage/SelectionCounter.tsx)
- [`manage/page.tsx`](app/(main)/subjects/%5BsubjectId%5D/records/%5BrecordId%5D/manage/page.tsx)에서 업로드 → 처리 중 → 완료/에러 흐름을 상태 머신 방식으로 관리하며, polling 기반으로 처리 상태를 추적합니다.

**파일 이동 페이지를 구현하였습니다.**

- [`manage/move/page.tsx`](app/(main)/subjects/%5BsubjectId%5D/records/%5BrecordId%5D/manage/move/page.tsx)에서 대상 주차를 선택하고 이동을 확정하는 [`FolderList`](app/_components/pages/manage/move/FolderList.tsx), [`MoveConfirmDialog`](app/_components/pages/manage/move/MoveConfirmDialog.tsx) 컴포넌트를 구현하였습니다.

**파일관리 페이지로의 네비게이션을 연결하였습니다.**

- 기록 상세 페이지의 파일관리 카드에서 `manage` 페이지로 이동하는 라우팅을 연결하였습니다.

**Mock 데이터 및 시뮬레이션 함수를 구현하였습니다.**

- 백엔드 연동 전 파일 업로드 흐름을 시뮬레이션하는 mock 함수를 [`_lib/mock/`](app/_lib/mock/) 아래에 구현하였습니다.

## Trouble Shooting ⚽️

- polling interval 누수 — 상태 전환/언마운트 시 `useEffect` cleanup에서 `clearInterval` 처리
- `handleDeleteFiles` 용량 오계산 — 클로저 캡처 이슈로 `setState(prev => ...)` 내부로 이동
- `handleStartLearning` / `handleRetryLearning` — 실패 파일 상태 미종료, 재시도 시 완료 파일 유실 버그 수정
- `FileUploadZone` — 드래그 앤 드롭 경로에서 파일 수·타입 검증이 적용되지 않던 문제 수정
- `truncateName` — 확장자가 긴 경우 `slice` 음수 인덱스 버그 수정
- `MoveConfirmDialog` — `onConfirm` 실패 시 `isLoading` 미정리 수정

## ⚠️ 주의 사항 / 고민점
- 백엔드 API 연동 (현재 mock 시뮬레이션으로 대체 중)
